### PR TITLE
Improve update performance

### DIFF
--- a/Core/Inc/gw_flash.h
+++ b/Core/Inc/gw_flash.h
@@ -28,6 +28,7 @@ void OSPI_ReadSR(uint8_t dest[1]);
 void OSPI_ReadCR(uint8_t dest[1]);
 const char* OSPI_GetFlashName(void);
 uint32_t OSPI_GetSmallestEraseSize(void);
+uint32_t OSPI_GetLargestEraseSize(void);
 uint32_t OSPI_GetFlashSize(void);
 
 void OSPI_Init(OSPI_HandleTypeDef *hospi);

--- a/Core/Src/firmware_update.c
+++ b/Core/Src/firmware_update.c
@@ -96,10 +96,30 @@ void boot_bank2(void)
     }
 }
 
+bool debounce_progress(unsigned int percentage, bool is_flash) {
+    static uint32_t debounce_time = 0;
+    uint32_t current_time = uptime_get();
+
+    if (percentage == 0 || percentage == 100 || (is_flash && percentage % 4 == 0)) {
+        debounce_time = current_time;
+        return true;
+    }
+
+    if (current_time - debounce_time < 1)
+        return false;
+
+    debounce_time = current_time;
+    return true;
+}
+
 void show_untar_progress_cb(unsigned int percentage, const char *file_name) {
-    gw_gui_draw_progress_bar(10, 80, 300, 8, percentage, RGB24_TO_RGB565(255, 255, 255), RGB24_TO_RGB565(255, 255, 255));
-    gw_gui_draw_text(10, 60, file_name, RGB24_TO_RGB565(255, 255, 255));
-    if (percentage == 100) {
+    if (!debounce_progress(percentage, false))
+        return;
+
+    if (percentage != 100) {
+        gw_gui_draw_progress_bar(10, 80, 300, 8, percentage, RGB24_TO_RGB565(255, 255, 255), RGB24_TO_RGB565(255, 255, 255));
+        gw_gui_draw_text(10, 60, file_name, RGB24_TO_RGB565(255, 255, 255));
+    } else {
         // Delete progress bar and text
         gw_gui_draw_text(10, 60, "", RGB24_TO_RGB565(255, 255, 255));
         gw_gui_draw_text(10, 80, "", RGB24_TO_RGB565(255, 255, 255));
@@ -107,9 +127,13 @@ void show_untar_progress_cb(unsigned int percentage, const char *file_name) {
 }
 
 void show_flash_progress_cb(unsigned int percentage) {
-    gw_gui_draw_progress_bar(10, 60, 300, 8, percentage, RGB24_TO_RGB565(255, 255, 255), RGB24_TO_RGB565(255, 255, 255));
+    if (!debounce_progress(percentage, true))
+        return;
+
     printf("Flashing progress: %d%%\n", percentage);
-    if (percentage == 100) {
+    if (percentage != 100) {
+        gw_gui_draw_progress_bar(10, 60, 300, 8, percentage, RGB24_TO_RGB565(255, 255, 255), RGB24_TO_RGB565(255, 255, 255));
+    } else {
         // Delete progress bar
         gw_gui_draw_text(10, 60, "", RGB24_TO_RGB565(255, 255, 255));
     }

--- a/Core/Src/gw_flash.c
+++ b/Core/Src/gw_flash.c
@@ -897,6 +897,8 @@ uint32_t OSPI_GetLargestEraseSize(void)
         if (erase_size == 0) {
             continue;
         }
+
+        return erase_size;
     }
 
     assert(0);

--- a/Core/Src/gw_flash.c
+++ b/Core/Src/gw_flash.c
@@ -888,6 +888,20 @@ uint32_t OSPI_GetSmallestEraseSize(void)
     return flash.config->erase_sizes[0];
 }
 
+uint32_t OSPI_GetLargestEraseSize(void)
+{
+    // Assumes that erase sizes are sorted: 4 > 3 > 2 > 1.
+    for (int i = 3; i >= 0; i--) {
+        uint32_t erase_size = flash.config->erase_sizes[i];
+
+        if (erase_size == 0) {
+            continue;
+        }
+    }
+
+    assert(0);
+}
+
 uint32_t OSPI_GetFlashSize(void)
 {
     return flash.size;
@@ -954,7 +968,11 @@ bool update_extflash(const char *path, extflash_progress_callback_t progress_cal
         return false;
     }
 
-    uint32_t block_size = OSPI_GetSmallestEraseSize();
+    if (progress_callback) {
+        progress_callback(0);
+    }
+
+    uint32_t block_size = OSPI_GetLargestEraseSize();
 
     OSPI_DisableMemoryMappedMode();
 

--- a/Core/Src/gw_intflash.c
+++ b/Core/Src/gw_intflash.c
@@ -78,6 +78,10 @@ bool update_intflash(uint8_t bank, const char *path, flash_progress_callback_t p
         return false;
     }
 
+    if (progress_callback) {
+        progress_callback(0);
+    }
+
     uint32_t flash_address = bank == 1 ? FLASH_BANK1_BASE : FLASH_BANK2_BASE;
 
     // File is present, erase bank

--- a/Core/Src/tar.c
+++ b/Core/Src/tar.c
@@ -7,6 +7,8 @@
 #include "tar.h"
 
 #define BLOCKSIZE 512  // TAR block size
+#define FILE_BUFFER_BLOCKS 128
+#define FILE_BUFFER_SIZE (BLOCKSIZE * FILE_BUFFER_BLOCKS)
 
 /* Create a directory, including parent directories if necessary */
 static FRESULT create_dir(const char *path) {
@@ -106,7 +108,7 @@ static int is_end_of_archive(const char *p) {
 
 /* Extract a TAR file from FatFs */
 bool extract_tar(const char *tar_path, const char *dest_path, size_t data_offset, progress_callback_t progress_callback) {
-    char block[BLOCKSIZE];
+    char buffer[FILE_BUFFER_SIZE];
     char tmp_path[256];
     char file_path[256];
     bool success = true;
@@ -131,11 +133,11 @@ bool extract_tar(const char *tar_path, const char *dest_path, size_t data_offset
     unsigned long current_position = 0;
 
     // Read blocks from the TAR file
-    while ((res = f_read(&tar_file, block, BLOCKSIZE, &br)) == FR_OK && br == BLOCKSIZE) {
+    while ((res = f_read(&tar_file, buffer, BLOCKSIZE, &br)) == FR_OK && br == BLOCKSIZE) {
         current_position += BLOCKSIZE;
 
         // Check for end of archive
-        if (is_end_of_archive(block)) {
+        if (is_end_of_archive(buffer)) {
             if (progress_callback) {
                 progress_callback(100, file_path);
             }
@@ -143,15 +145,15 @@ bool extract_tar(const char *tar_path, const char *dest_path, size_t data_offset
         }
 
         // Verify the checksum
-        if (!verify_checksum(block)) {
+        if (!verify_checksum(buffer)) {
             success = false;
             break;
         }
 
         // Get file name and size
-        strncpy(tmp_path, block, 100);
+        strncpy(tmp_path, buffer, 100);
         tmp_path[100] = '\0';  // Ensure null-termination
-        unsigned long file_size = parseoct(block + 124, 12);
+        unsigned long file_size = parseoct(buffer + 124, 12);
 
         if (strlen(dest_path) + strlen(tmp_path) + 2 > sizeof(file_path)) {
             success = false;
@@ -164,7 +166,7 @@ bool extract_tar(const char *tar_path, const char *dest_path, size_t data_offset
         snprintf(file_path, sizeof(file_path), "%s/%s", dest_path, tmp_path);
 #pragma GCC diagnostic pop
 
-        if (block[156] == '5') {  // Directory
+        if (buffer[156] == '5') {  // Directory
             res = create_dir(file_path);
             if (res != FR_OK) {
                 break;
@@ -178,22 +180,30 @@ bool extract_tar(const char *tar_path, const char *dest_path, size_t data_offset
 
             // Write the file content
             while (file_size > 0) {
-                UINT to_read = (file_size > BLOCKSIZE) ? BLOCKSIZE : file_size;
-                res = f_read(&tar_file, block, BLOCKSIZE, &br);
-                current_position += BLOCKSIZE;
-                if (res != FR_OK || br < BLOCKSIZE) {
+                if (progress_callback) {
+                    progress_callback(0, file_path);
+                }
+
+                UINT file_blocks_remaining = ((file_size - 1) / BLOCKSIZE) + 1;
+                UINT blocks_to_read = (file_blocks_remaining > FILE_BUFFER_BLOCKS) ? FILE_BUFFER_BLOCKS : file_blocks_remaining;
+                UINT to_read = blocks_to_read * BLOCKSIZE;
+
+                res = f_read(&tar_file, buffer, to_read, &br);
+                current_position += to_read;
+                if (res != FR_OK || br < to_read) {
                     success = false;
                     f_close(&out_file);
                     break;
                 }
 
-                res = f_write(&out_file, block, to_read, &bw);
-                if (res != FR_OK || bw < to_read) {
+                UINT to_write = (file_size > to_read) ? to_read : file_size;
+                res = f_write(&out_file, buffer, to_write, &bw);
+                if (res != FR_OK || bw < to_write) {
                     f_close(&out_file);
                     break;
                 }
 
-                file_size -= to_read;
+                file_size -= to_write;
                 if (progress_callback) {
                     unsigned int percentage = (unsigned int)((current_position * 100) / total_tar_size);
                     progress_callback(percentage, file_path);
@@ -201,12 +211,6 @@ bool extract_tar(const char *tar_path, const char *dest_path, size_t data_offset
             }
 
             f_close(&out_file);
-        }
-
-        // Skip any padding
-        unsigned long skip = ((file_size + BLOCKSIZE - 1) / BLOCKSIZE) * BLOCKSIZE - file_size;
-        if (skip > 0) {
-            f_lseek(&tar_file, f_tell(&tar_file) + skip);
         }
     }
     f_close(&tar_file);


### PR DESCRIPTION
Not the most important thing to improve, but on my SD card, update time decreased from 60 seconds to 31 seconds

-------------
feat: avoid filesystem thrashing by using a large read buffer
feat: use largest erase block when erasing extflash
feat: debounce progress UI to reduce CPU time spent drawing